### PR TITLE
Add `dnsIP` as an exposed property

### DIFF
--- a/jobs/squid/spec
+++ b/jobs/squid/spec
@@ -37,3 +37,6 @@ properties:
       http_access deny !Safe_ports
       http_access deny CONNECT !SSL_ports
       http_access allow localnet
+
+  dnsIP:
+    description: IP address used for dns in place of /etc/resolv.conf

--- a/jobs/squid/templates/config/squid.conf
+++ b/jobs/squid/templates/config/squid.conf
@@ -27,3 +27,5 @@ http_access deny all
 
 # never cache
 cache deny all
+
+dns_nameservers <%= p('dnsIP') %>


### PR DESCRIPTION
Expose Squid `dns_nameservers` configuration

Co-authored-by: Fei Yang <fyang@pivotal.io>
Co-authored-by: Tanay Kothari <tanayk2610@gmail.com>